### PR TITLE
Add automated CI pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,65 @@
+name: Build and Release Executables
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-13]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install PyInstaller
+        run: pip install pyinstaller
+
+      - name: Build Executable
+        env:
+          OS: ${{ matrix.os }}
+        shell: bash
+        run: |
+          python -m PyInstaller  --distpath o4xp_2_xp12/. --workpath ./OBJ --onefile o4xp_2_xp12.py
+          if [[ "$OS" = "windows-latest" ]]; then 
+              mv o4xp_2_xp12/o4xp_2_xp12.exe o4xp_2_xp12.exe; 
+          else
+              mv o4xp_2_xp12/o4xp_2_xp12 o4xp_2_xp12_$OS;
+          fi
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.os }}-build
+          path: |
+            o4xp_2_xp12_${{ matrix.os }}
+            o4xp_2_xp12.exe
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: ./build
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ${{ github.workspace }}/build/windows-latest-build/o4xp_2_xp12.exe
+            ${{ github.workspace }}/build/ubuntu-latest-build/o4xp_2_xp12_ubuntu-latest
+            ${{ github.workspace }}/build/macos-13-build/o4xp_2_xp12_macos-13
+          prerelease: ${{ contains(github.ref_name, '-') }}


### PR DESCRIPTION
- Build binaries for 3 different OS 
- It supports automatically SemVer format 
   - a tag with vX.X.X is automatically marked as latest release
   - a tag with vX.X.X-alpha.1 is marked as prerelease

## How release
On any commit/branch you want to release, you just need to tag it. for example, if you want to release from current branch/commit for version v1.0.0
```
git tag v1.0.0
git push --tags
```
example GH Action: https://github.com/xairline/o4xp_2_xp12/actions/runs/11761402200
example release: https://github.com/xairline/o4xp_2_xp12/releases/tag/v0.0.0

if you want to release a prerelease version:
```
git tag v1.0.0-alpha.1
git push --tags
```
example GH Action: https://github.com/xairline/o4xp_2_xp12/actions/runs/11761402838
example release: https://github.com/xairline/o4xp_2_xp12/releases/tag/v0.0.0-alpha.1

### NOTE
What i normally do with org post is that i add files by URL:
![image](https://github.com/user-attachments/assets/338a0faf-1b26-4243-ba08-99b8d5d9676b)
and the url is always point to latest (example: https://github.com/xairline/xa-snow/releases/latest/download/xa-snow.zip) in this way, when i have a new version, just need to update the post saying i have a new one without updating the link or manually upload the file.

The release process is purely driven by git cmd (The industry call it GitOps). which means it will give you a full recorded history of which release is from what code